### PR TITLE
Update overall_statistics_card.dart

### DIFF
--- a/lib/statistics/overall_statistics_card.dart
+++ b/lib/statistics/overall_statistics_card.dart
@@ -1,8 +1,9 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
-import 'package:habo/settings/settings_manager.dart';
-import 'package:habo/statistics/statistics.dart';
 import 'package:provider/provider.dart';
+import 'package:habo/statistics/statistics.dart';
+
+import '../settings/settings_manager.dart';
 
 class OverallStatisticsCard extends StatelessWidget {
   const OverallStatisticsCard(
@@ -82,23 +83,9 @@ class OverallStatisticsCard extends StatelessWidget {
                     ),
                   ],
                 ),
-                Row(
+                const Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      Icons.last_page,
-                      color:
-                          Provider.of<SettingsManager>(context, listen: false)
-                              .skipColor,
-                    ),
-                    Text(
-                      total.skips.toString(),
-                      style: const TextStyle(
-                        fontSize: 24,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ],
+                  children: [],
                 ),
                 Row(
                   mainAxisSize: MainAxisSize.min,
@@ -135,19 +122,6 @@ class OverallStatisticsCard extends StatelessWidget {
           value: total.checks.toDouble(),
           badgeWidget: const Icon(
             Icons.check,
-            color: Colors.white,
-          ),
-          title: "",
-          radius: 25.0,
-          titleStyle: const TextStyle(
-              fontSize: 16.0, fontWeight: FontWeight.bold, color: Colors.white),
-        ),
-      if (total.skips != 0)
-        PieChartSectionData(
-          color: Provider.of<SettingsManager>(context, listen: false).skipColor,
-          value: total.skips.toDouble(),
-          badgeWidget: const Icon(
-            Icons.last_page,
             color: Colors.white,
           ),
           title: "",


### PR DESCRIPTION
By adding the value: value parameter in the OneDayButton widget and passing the value variable that increments from 1 to 40, you can associate these ascending values with the dates generated in your GridView.builder.

Remove Calender By  GridView.builder in habit screen to generate 40 buttons in 7 rows.

I have removed the monthly graph to declutter the report and focus on more essential data, optimizing space and improving readability

Remove skip method function from ionbutton because there's no option to skip Namaz.

Change Habo-icon to prayer-Icon and name in splash screen.

Removed two day rule functions.

Change appname Habo  to Namaz tracker. 

upgrade  some packages because some packages are constraint to older version.

When you go to statistics_Screen data automatic added to FirebaseCloud store.

Removed unnecceassary functions and files from  project  optimizing space and improving readability.