### PR TITLE
fix: Update time display format to include AM/PM notation

### DIFF
--- a/lib/habits/edit_habit_screen.dart
+++ b/lib/habits/edit_habit_screen.dart
@@ -698,7 +698,8 @@ class _EditHabitScreenState extends State<EditHabitScreen> {
                                 }
                               },
                               child: Text(
-                                '${notTime.hourOfPeriod.toString().padLeft(2, '0')}:${notTime.minute.toString().padLeft(2, '0')} ${notTime.period.name.toUpperCase()}',
+                                MaterialLocalizations.of(context)
+                                    .formatTimeOfDay(notTime),
                                 style: TextStyle(
                                     color: (notification)
                                         ? null

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -234,10 +234,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                               }
                             },
                             child: Text(
-                              '${Provider.of<SettingsManager>(context).getDailyNot.hourOfPeriod.toString().padLeft(2, '0')}'
-                              ':'
-                              '${Provider.of<SettingsManager>(context).getDailyNot.minute.toString().padLeft(2, '0')} '
-                              '${Provider.of<SettingsManager>(context).getDailyNot.period.name.toUpperCase()}',
+                              MaterialLocalizations.of(context).formatTimeOfDay(
+                                  Provider.of<SettingsManager>(context)
+                                      .getDailyNot),
                               style: TextStyle(
                                   color: (Provider.of<SettingsManager>(context)
                                           .getShowDailyNot)


### PR DESCRIPTION
## 📌 Related Issue
<!-- Please link the issue this PR addresses (e.g. "Closes #123"). -->
Closes #
#110 
---

## ✨ Description
<!-- A clear and concise description of what this PR does. -->
Update time display format to include AM/PM notation
---

## ✅ Type of Change
- [x] 🐞 Bug fix    

---

## 🔍 Checklist
Please check all that apply:
- [x] The PR is linked to a related issue.  
- [x] Only relevant changes are included (no unrelated formatting/whitespace).  
- [x] Tested on **Android**.  
- [x] Tested on **iOS**.  
- [x] Code passes linting/formatting checks.  
- [x] Added/updated tests (if applicable).  

---

## 📸 Screenshots (if applicable)
<!-- Add before/after screenshots or screen recordings if UI-related. -->
before
<img width="1008" height="692" alt="532565758-0b9ae5e1-55f7-497b-8e9f-b30084d6bac8" src="https://github.com/user-attachments/assets/ca414393-c373-49f6-8fad-6eccac4c8e21" />


after
<img width="1272" height="2070" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-02-01 at 12 04 15" src="https://github.com/user-attachments/assets/a919d48f-576e-41d5-96da-7c1717faa560" />

<img width="1310" height="2315" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-02-01 at 16 45 02" src="https://github.com/user-attachments/assets/d0532f9c-9af5-444d-a8fa-c6e999ce327a" />

